### PR TITLE
Removed iPhone App and Android App from the features list in website

### DIFF
--- a/_includes/features.html
+++ b/_includes/features.html
@@ -61,28 +61,6 @@
                 <div class="col-md-4">
                 </div>
             </div>
-            <div class="row text-center">
-                <div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-apple fa-stack-1x fa-inverse"></i>
-                    </span>
-                    <h4 class="service-heading">iPhone App</h4>
-                    <p class="text-muted">Native iPhone App is available which provides core functionality.</p>
-                </div>
-                <div class="col-md-4">
-                    <span class="fa-stack fa-4x">
-                        <i class="fa fa-circle fa-stack-2x text-primary"></i>
-                        <i class="fa fa-android fa-stack-1x fa-inverse"></i>
-                    </span>
-                    <h4 class="service-heading">Android App</h4>
-                    <p class="text-muted">Native Android App is available which provides core functionality..</p>
-                </div>
-                <div class="col-md-4">
-                </div>
-                <div class="col-md-4">
-                </div>
-            </div>
             <hr>
             <div class="row">
                 <div class="col-md-4">


### PR DESCRIPTION
I have removed iPhone App and Android App features from the webpage as it is no longer developed/supported.